### PR TITLE
update reader `get_new_blocks` to check for new sequencer blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "sequencer-relayer"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/sequencer-relayer?rev=0193e7d9ce4a02c263b57ffd7465f952a63be332#0193e7d9ce4a02c263b57ffd7465f952a63be332"
+source = "git+https://github.com/astriaorg/sequencer-relayer#f719a7ff79562efe50e9ce9e542bbf415b9550c2"
 dependencies = [
  "base64 0.21.0",
  "bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "sequencer-relayer"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/sequencer-relayer?rev=6c6cb95#6c6cb9553eefca4ab3009f12dd27d2747ee63130"
+source = "git+https://github.com/astriaorg/sequencer-relayer?rev=0193e7d9ce4a02c263b57ffd7465f952a63be332#0193e7d9ce4a02c263b57ffd7465f952a63be332"
 dependencies = [
  "base64 0.21.0",
  "bech32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 [[package]]
 name = "sequencer-relayer"
 version = "0.1.0"
-source = "git+https://github.com/astriaorg/sequencer-relayer#f719a7ff79562efe50e9ce9e542bbf415b9550c2"
+source = "git+https://github.com/astriaorg/sequencer-relayer?rev=f719a7ff79562efe50e9ce9e542bbf415b9550c2#f719a7ff79562efe50e9ce9e542bbf415b9550c2"
 dependencies = [
  "base64 0.21.0",
  "bech32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ figment = { version = "0.10.8", features = ["toml", "env"] }
 flexi_logger = "0.24.2"
 log = "0.4.17"
 rs-cnc = { git = "https://github.com/astriaorg/rs-cnc", rev = "e0b45d6" }
-sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer", rev = "0193e7d9ce4a02c263b57ffd7465f952a63be332" }
+sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer" }
 serde = "1.0.152"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ figment = { version = "0.10.8", features = ["toml", "env"] }
 flexi_logger = "0.24.2"
 log = "0.4.17"
 rs-cnc = { git = "https://github.com/astriaorg/rs-cnc", rev = "e0b45d6" }
-sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer" }
+sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer", rev = "f719a7ff79562efe50e9ce9e542bbf415b9550c2" }
 serde = "1.0.152"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "signal"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ figment = { version = "0.10.8", features = ["toml", "env"] }
 flexi_logger = "0.24.2"
 log = "0.4.17"
 rs-cnc = { git = "https://github.com/astriaorg/rs-cnc", rev = "e0b45d6" }
-sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer", rev = "6c6cb95" }
+sequencer-relayer = { git = "https://github.com/astriaorg/sequencer-relayer", rev = "0193e7d9ce4a02c263b57ffd7465f952a63be332" }
 serde = "1.0.152"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["macros", "rt-multi-thread", "signal"] }

--- a/README.md
+++ b/README.md
@@ -6,11 +6,9 @@ Coordinates blocks between the data layer and the execution layer.
 
 * create `ConductorConfig.toml` in the repo root and populate accordingly, e.g.
 
-Note: I've been generating random namespace ids for development. [See how here](https://go.dev/play/p/7ltvaj8lhRl)
-
 ```
 celestia_node_url = "http://localhost:26659"
-namespace_id = "b860ccf0e97fdf6c"
+chain_id = "test"
 rpc_address = "https://[::1]:50051"
 ```
 

--- a/README.md
+++ b/README.md
@@ -15,3 +15,34 @@ rpc_address = "https://[::1]:50051"
 ```
 
 * run `cargo run`
+
+### Tests
+
+To run the tests, you need to build and run [`sequencer-relayer`](https://github.com/astriaorg/sequencer-relayer.git) as well as a Celestia cluster and Metro.
+
+Run [metro](https://github.com/astriaorg/metro.git):
+```bash
+git clone https://github.com/astriaorg/metro.git
+cd metro
+git checkout noot/msg-type
+make install
+bash scripts/single-node.sh
+```
+
+Run a Celestia cluster:
+```bash
+git clone https://github.com/astriaorg/sequencer-relayer.git
+cd sequencer-relayer
+docker compose -f docker/test-docker-compose.yml up -d bridge0
+```
+
+To run the relayer, inside `sequencer-relayer/`:
+```bash
+cargo build
+./target/debug/relayer
+```
+
+Then, you can run the tests:
+```bash
+cargo test
+```

--- a/src/alert.rs
+++ b/src/alert.rs
@@ -14,6 +14,7 @@ pub(crate) type AlertReceiver = UnboundedReceiver<Alert>;
 
 /// The alerts that the driver may send the driver user.
 #[derive(Debug)]
+#[allow(dead_code)] // TODO: remove this
 pub(crate) enum Alert {
     /// Send when a block has been received from the data layer.
     BlockReceived {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -8,10 +8,10 @@ pub(crate) struct Cli {
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
     pub(crate) celestia_node_url: Option<String>,
 
-    /// Namespace ID as a string; the hex encoding of a [u8; 8]
-    #[arg(long = "namespace-id")]
+    /// Chain ID as a string
+    #[arg(long = "chain-id")]
     #[serde(skip_serializing_if = "::std::option::Option::is_none")]
-    pub(crate) namespace_id: Option<String>,
+    pub(crate) chain_id: Option<String>,
 
     /// Address of the execution RPC server.
     #[arg(long = "rpc-address")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,8 +6,8 @@ pub(crate) struct Config {
     /// URL of the Celestia Node
     pub(crate) celestia_node_url: String,
 
-    /// Namespace that we want to work in
-    pub(crate) namespace_id: String,
+    /// Chain ID that we want to work in
+    pub(crate) chain_id: String,
 
     /// Address of the RPC server for execution
     pub(crate) rpc_address: String,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre::Result;
-use rs_cnc::NamespacedDataResponse;
 use sequencer_relayer::sequencer_block::SequencerBlock;
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -36,7 +36,7 @@ pub(crate) enum ExecutorCommand {
     /// Command for when a block is received
     BlockReceived {
         // FIXME - this will probably not be a NamespacedDataResponse ultimately
-        block: SequencerBlock,
+        block: Box<SequencerBlock>,
     },
 
     Shutdown,
@@ -79,7 +79,7 @@ impl Executor {
             match cmd {
                 ExecutorCommand::BlockReceived { block } => {
                     log::info!("ExecutorCommand::BlockReceived {:#?}", block);
-                    self.execute_block(block).await?;
+                    self.execute_block(*block).await?;
                 }
                 ExecutorCommand::Shutdown => {
                     log::info!("Shutting down executor event loop.");

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -30,12 +30,10 @@ pub(crate) async fn spawn(
     Ok((join_handle, executor_tx))
 }
 
-#[allow(dead_code)] // TODO - remove after developing
 #[derive(Debug)]
 pub(crate) enum ExecutorCommand {
     /// Command for when a block is received
     BlockReceived {
-        // FIXME - this will probably not be a NamespacedDataResponse ultimately
         block: Box<SequencerBlock>,
     },
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,4 @@
 use color_eyre::eyre::Result;
-use tokio;
 
 use astria_conductor::run;
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,8 +1,8 @@
-use color_eyre::eyre::{eyre, Result};
-use rs_cnc::{CelestiaNodeClient, NamespacedDataResponse};
-use sequencer_relayer::da::CelestiaClient;
-use sequencer_relayer::sequencer::SequencerClient;
-use sequencer_relayer::sequencer_block::SequencerBlock;
+use color_eyre::eyre::Result;
+use sequencer_relayer::{
+    da::CelestiaClient,
+    sequencer_block::{Namespace, SequencerBlock},
+};
 use tokio::{
     sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
     task,
@@ -26,7 +26,12 @@ pub(crate) fn spawn(
     executor_tx: executor::Sender,
 ) -> Result<(JoinHandle, Sender)> {
     log::info!("Spawning reader task.");
-    let (mut reader, reader_tx) = Reader::new(conf, driver_tx, executor_tx)?;
+    let (mut reader, reader_tx) = Reader::new(
+        &conf.celestia_node_url,
+        Namespace::from_string(&conf.chain_id)?,
+        driver_tx,
+        executor_tx,
+    )?;
     let join_handle = task::spawn(async move { reader.run().await });
     log::info!("Spawned reader task.");
     Ok((join_handle, reader_tx))
@@ -54,27 +59,25 @@ struct Reader {
     executor_tx: executor::Sender,
 
     /// The client used to communicate with Celestia.
-    // celestia_node_client: CelestiaNodeClient,
-
-    /// The client used to communicate with Celestia.
     celestia_client: CelestiaClient,
 
     /// Namespace ID
-    namespace_id: String,
+    namespace_id: Namespace,
 
-    /// Keep track of the last block height fetched
+    /// Keep track of the last block height fetched from Celestia
     last_block_height: u64,
 }
 
 impl Reader {
     /// Creates a new Reader instance and returns a command sender and an alert receiver.
     fn new(
-        conf: &Config,
+        celestia_node_url: &str,
+        namespace_id: Namespace,
         driver_tx: driver::Sender,
         executor_tx: executor::Sender,
     ) -> Result<(Self, Sender)> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let celestia_client = CelestiaClient::new(conf.celestia_node_url.to_owned())?;
+        let celestia_client = CelestiaClient::new(celestia_node_url.to_owned())?;
         Ok((
             Self {
                 cmd_tx: cmd_tx.clone(),
@@ -82,7 +85,7 @@ impl Reader {
                 driver_tx,
                 executor_tx,
                 celestia_client,
-                namespace_id: conf.namespace_id.to_owned(),
+                namespace_id: namespace_id,
                 last_block_height: 0,
             },
             cmd_tx,
@@ -95,7 +98,10 @@ impl Reader {
         while let Some(cmd) = self.cmd_rx.recv().await {
             match cmd {
                 ReaderCommand::GetNewBlocks => {
-                    self.get_new_blocks().await?;
+                    let blocks = self.get_new_blocks().await?;
+                    for block in blocks {
+                        self.process_block(block).await?;
+                    }
                 }
                 ReaderCommand::Shutdown => {
                     log::info!("Shutting down reader event loop.");
@@ -107,54 +113,50 @@ impl Reader {
         Ok(())
     }
 
-    /// This function is responsible for fetching all the latest blocks
-    async fn get_new_blocks(&mut self) -> Result<()> {
+    /// get_new_blocks fetches any new sequencer blocks from Celestia.
+    async fn get_new_blocks(&mut self) -> Result<Vec<SequencerBlock>> {
         log::info!("ReaderCommand::GetNewBlocks");
+        let mut blocks = vec![];
 
-        println!("get_new_blocks {:?}", self.last_block_height);
-        // get most recent block
-        // NOTE - requesting w/ height of 0 gives us the last block. this isn't documented.
-        let res = self.celestia_client.get_blocks(0, None).await;
+        // get the latest celestia block height
+        let latest_height = self.celestia_client.get_latest_height().await?;
 
-        match res {
-            Ok(block) => {
-                println!("block: {:?}", block);
-                // return early if block is empty
-                // FIXME - these shouldn't be empty
-                if block.is_empty() {
-                    return Ok(());
+        // check for any new sequencer blocks written from the previous to current block height
+        for height in self.last_block_height..latest_height {
+            let res = self.get_block(height).await;
+
+            match res {
+                Ok(block) => {
+                    println!("block: {:?}", block);
+
+                    // continue as celestia block doesn't have a sequencer block
+                    let Some(block) = block else {
+                        continue;
+                    };
+
+                    // sequencer block's height
+                    let height = block.header.height.parse::<u64>()?;
+                    println!("sequencer block height: {:?}", height);
+                    blocks.push(block);
                 }
-
-                let block = block.into_iter().nth(0).ok_or(eyre!("No block found"))?;
-                if let height = block.header.height.parse::<u64>().unwrap() {
-                    println!("height: {:?}", height);
-                    // get blocks between current height and last height received and send to executor
-                    for h in (self.last_block_height + 1)..(height) {
-                        let block = self.get_block(h).await?;
-                        self.process_block(block).await?;
-                    }
-                    // process the most recent block, which is actually the first one we requested above
-                    self.process_block(block).await?;
+                Err(e) => {
+                    // just log the error for now.
+                    // any blocks that weren't fetched will be handled in the next cycle
+                    log::error!("{}", e.to_string());
                 }
-            }
-            Err(e) => {
-                // just log the error for now.
-                // any blocks that weren't fetched will be handled in the next cycle
-                log::error!("{}", e.to_string());
             }
         }
 
-        Ok(())
+        self.last_block_height = latest_height;
+        Ok(blocks)
     }
 
-    /// Gets an individual block
-    async fn get_block(&mut self, height: u64) -> Result<SequencerBlock> {
-        println!("sequencer block get_block: {:?}", height);
+    /// Gets an individual block for a given Celestia height
+    async fn get_block(&mut self, height: u64) -> Result<Option<SequencerBlock>> {
         let res = self.celestia_client.get_blocks(height, None).await?;
-        println!("sequencer block get_block: {:?}", res);
-
-        let res = res.into_iter().nth(0).ok_or(eyre!("No block found"))?;
-        Ok(res)
+        // TODO: we need to verify the block using the expected proposer's key (by passing in their pubkey above)
+        // and ensure there's only one block signed by them
+        Ok(res.into_iter().nth(0))
     }
 
     /// Processes an individual block
@@ -164,5 +166,31 @@ impl Reader {
             .send(executor::ExecutorCommand::BlockReceived { block })?;
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use sequencer_relayer::sequencer_block::DEFAULT_NAMESPACE;
+
+    const DEFAULT_CELESTIA_ENDPOINT: &str = "http://localhost:26659";
+
+    #[tokio::test]
+    async fn test_reader_get_new_blocks() {
+        let (driver_tx, _) = mpsc::unbounded_channel();
+        let (executor_tx, _) = mpsc::unbounded_channel();
+
+        let (mut reader, _reader_tx) = Reader::new(
+            DEFAULT_CELESTIA_ENDPOINT,
+            DEFAULT_NAMESPACE.clone(),
+            driver_tx,
+            executor_tx,
+        )
+        .unwrap();
+
+        let blocks = reader.get_new_blocks().await.unwrap();
+        println!("blocks: {:?}", blocks);
+        assert!(blocks.len() > 0);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -86,7 +86,7 @@ impl Reader {
                 executor_tx,
                 celestia_client,
                 namespace,
-                last_block_height: 0,
+                last_block_height: 1,
             },
             cmd_tx,
         ))


### PR DESCRIPTION
- update reader `get_new_blocks` to check for new sequencer blocks by checking celestia blocks from prev to latest
- add a unit test for this and add readme instructions
- i also updated the cli/config `namespace_id` to be `chain_id` so you can put any string and it internally converts it into a namespace, i figured this would be simpler. i also don't think the namespace is used anywhere yet anyways
- run fmt/clippy